### PR TITLE
issues#56 新增404頁面

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -28,9 +28,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-feikv0pwtpq8vslcadt@)&g@h&l2xmp1g)qenll7=fulvih@1g"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,13 +1,11 @@
 from django.contrib import admin
 from django.urls import path, include
-from .views import IndexView, PremiumView
+from .views import IndexView, PremiumView, custom_page_not_found_view
 from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls import handler404
-from django.shortcuts import render
 
-def custom_page_not_found_view(request, exception):
-    return render(request, "shared/404.html", {}, status=404)
+
 
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),

--- a/project/urls.py
+++ b/project/urls.py
@@ -3,6 +3,11 @@ from django.urls import path, include
 from .views import IndexView, PremiumView
 from django.conf import settings
 from django.conf.urls.static import static
+from django.conf.urls import handler404
+from django.shortcuts import render
+
+def custom_page_not_found_view(request, exception):
+    return render(request, "shared/404.html", {}, status=404)
 
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
@@ -19,3 +24,5 @@ urlpatterns = [
     path("articles/", include("articles.urls")),
     path("admin/", admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+handler404 = custom_page_not_found_view

--- a/project/views.py
+++ b/project/views.py
@@ -1,8 +1,11 @@
 from django.views.generic import TemplateView
-
+from django.shortcuts import render
 
 class IndexView(TemplateView):
     template_name = "pages/index.html"
 
 class PremiumView(TemplateView):
     template_name = "pages/premium.html"
+
+def custom_page_not_found_view(request, exception):
+    return render(request, "shared/404.html", {}, status=404)

--- a/templates/shared/404.html
+++ b/templates/shared/404.html
@@ -1,0 +1,22 @@
+{% block content %}
+<script src="https://cdn.tailwindcss.com"></script>
+<div class="bg-gray-200 w-full px-16 md:px-0 h-screen flex items-center justify-center">
+    <div
+        class="bg-white border border-gray-200 flex flex-col items-center justify-center px-4 md:px-8 lg:px-24 py-8 rounded-lg shadow-2xl">
+        <p class="text-6xl md:text-7xl lg:text-9xl font-bold tracking-wider text-orange-600">404</p>
+        <p class="text-2xl md:text-3xl lg:text-5xl font-bold tracking-wider text-gray-500 mt-4">Page Not Found</p>
+        <p class="text-gray-500 mt-4 pb-4 border-b-2 text-center">Sorry, the page you are looking for could not be
+            found.</p>
+        <a href="{% url 'index' %}"
+            class="flex items-center space-x-2 bg-blue-600 hover:bg-blue-700 text-gray-100 px-4 py-2 mt-6 rounded transition duration-150"
+            title="回首頁">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd"
+                    d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z"
+                    clip-rule="evenodd"></path>
+            </svg>
+            <span>回首頁</span>
+        </a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
因客制404頁面蓋掉內建的，需要在settings.py中將DEBUG改成False，會導致錯誤訊息不會顯示，要看錯誤訊息需要手動到settings.py中將DEBUG改成True
<img width="1673" alt="截圖 2024-05-27 17 54 22" src="https://github.com/astrocamp/16th-Diswork/assets/99263019/051ec8d2-ed8d-4a4d-83ff-03e791d96077">
