### PR TITLE
issues#58 新增留言按讚總數

### DIFF
--- a/articles/views.py
+++ b/articles/views.py
@@ -42,7 +42,7 @@ class ShowView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["comments"] = self.object.comments.all().order_by("-id")
+        context["comments"] = self.object.comments.annotate(like_count=Count("like_comment"))
         return context
 
     def post(self, request, pk):

--- a/templates/articles/article_detail.html
+++ b/templates/articles/article_detail.html
@@ -62,7 +62,8 @@
 
 
         <div class="flex justify-end px-4 py-2">
-          <div class="flex">
+          <div class="flex items-center">
+            <p class="mr-3">留言按讚總數: {{comment.like_count}}</p>
             <form hx-post="{% url 'comments:add_like' comment.id %}" hx-swap="none">
               {% csrf_token %}
               <button


### PR DESCRIPTION
1.  templates/articles/article_detail 頁面增加留言按讚總數.
2.   articles/view 增加 每個留言按讚總數 邏輯
3. [影片](https://youtu.be/1LXqxbeAFes)
因為一定有人提問所以我先貼出來解釋:
 context["comments"] = self.object.comments.annotate(like_count=Count('likes')).order_by("-id")
 self.object 是 Article 這當下的 model 對像  self.object.comments 就是從當下的 Article 去拿所有的留言，可是我要在 commnets 的每一筆留這都拿到按讚總數。
我的第一次做法是先拿到所有的留言然後跑迴圈，在每一個 comment 加入 like_count 屬性，但這樣的應該挺耗效能。
所以又查找資料 annotate 的方法跟 Count 方法， annotate 針對查詢的對像加上一個查詢後給出的名稱，裡面的值使用 Count 來統計 針對本篇文章所有留言的數量。
給個官方連結 [annotate ](https://docs.djangoproject.com/en/5.0/topics/db/aggregation/)
這個方法是我之前要解決聊天訊息做二次排序查找的方法，想不到在這裡找到，大家可以花點時間看一下。

