### PR TITLE
issues#60 新增文章頁面切版

### DIFF
--- a/articles/views.py
+++ b/articles/views.py
@@ -33,6 +33,7 @@ class NewView(FormView):
     template_name = "articles/new.html"
     form_class = ArticleForm
     success_url = reverse_lazy("artucles:index")
+
     def get_initial(self):
         initial = super().get_initial()
         initial['author'] = self.request.user.username

--- a/articles/views.py
+++ b/articles/views.py
@@ -95,7 +95,6 @@ class ShowView(DetailView):
 @require_POST
 def create(request):
     form = ArticleForm(request.POST)
-    print(form.is_valid())
     if form.is_valid():
         article = form.save(commit=False)
         article.author = request.user

--- a/templates/articles/article_detail.html
+++ b/templates/articles/article_detail.html
@@ -1,3 +1,4 @@
+{% comment %} article_detail.html {% endcomment %}
 {% extends 'boards/base.html' %}
 {% block content %}
 <div class="relative block w-full h-screen overflow-hidden bg-opacity-60">
@@ -85,5 +86,6 @@
       </form>
     </div>
   </div>
+  
 </div>
 {% endblock %}

--- a/templates/articles/article_detail.html
+++ b/templates/articles/article_detail.html
@@ -1,4 +1,4 @@
-{% comment %} article_detail.html {% endcomment %}
+
 {% extends 'boards/base.html' %}
 {% block content %}
 <div class="relative block w-full h-screen overflow-hidden bg-opacity-60">

--- a/templates/articles/new.html
+++ b/templates/articles/new.html
@@ -1,15 +1,14 @@
 {% extends "layouts/base.html" %}
 
 {% block content %}
-<div class="block bg-slate-300 rounded-md p-6 max-w-xl mx-auto my-5 relative" style="height: calc(100vh - 96.97px);">
+<div class="flex flex-col bg-slate-300 rounded-md p-6 max-w-xl mx-auto mt-[62px] relative" style="height: calc(100vh - 96.97px);">
     <div class="flex flex-col w-24">
         <h2 class="inline-block text-2xl pb-4 mb-4 border-b-2 border-black">新增文章</h2>
         <button class="inline-flex items-center justify-center text-sm bg-gray-900 hover:bg-gray-700 text-white rounded-md py-2">
             工作版
         </button>
-        <!-- {{ form.category }} -->
     </div>
-    <div>
+    <div class="flex-1">
         <form action="{% url 'articles:add' %}" method="POST">
             {% csrf_token %}
             <div class="my-4">

--- a/templates/articles/new.html
+++ b/templates/articles/new.html
@@ -27,7 +27,7 @@
             {{ form.category }}
 
             <div class="flex justify-center gap-2">
-                <a class="inline-flex items-center justify-center text-sm hover:bg-slate-400 text-black rounded-md px-6 py-3" value="取消" href="{% url 'articles:index' %}">取消</a>
+                <a class="inline-flex items-center justify-center text-sm hover:bg-slate-400 text-black rounded-md px-6 py-3" value="取消" href="{% url 'articles:index' category.id %}">取消</a>
                 <button class="inline-flex items-center justify-center text-sm bg-sky-500 hover:bg-sky-300 text-white rounded-md px-6 py-3" type="submit" value="新增">新增</button>
             </div>
         </form>

--- a/templates/articles/new.html
+++ b/templates/articles/new.html
@@ -24,7 +24,7 @@
                 <label class="block text-xl text-black font-medium mb-1" for="id_content">{{ form.content.label }}</label>
                 {{ form.content }}
             </div>
-
+            {{ form.category }}
 
             <div class="flex justify-center gap-2">
                 <a class="inline-flex items-center justify-center text-sm hover:bg-slate-400 text-black rounded-md px-6 py-3" value="取消" href="{% url 'articles:index' %}">取消</a>

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -1,5 +1,5 @@
 <nav
-  class="fixed top-0 flex flex-col w-full px-8 py-1 font-sans text-center text-white bg-transparent shadow backdrop-blur-sm backdrop-filter sm:flex-row sm:text-left sm:justify-between sm:items-baseline">
+  class="fixed top-0 flex flex-col w-full px-8 py-1 font-sans text-center text-white bg-transparent shadow backdrop-blur-sm backdrop-filter sm:flex-row sm:text-left sm:justify-between sm:items-baseline z-[99]">
   <div class="flex items-center justify-between w-full">
     <div class="flex items-center">
       <a href="{% url 'root' %}">


### PR DESCRIPTION
1. 調整原先一次性的forms表單引入改成分次引入
2. 新增文章下方的深色按鈕區塊為之後category各版顯示


https://github.com/astrocamp/16th-Diswork/assets/122122171/5f504a2a-2270-48c5-b361-9590c2bb9bd6

