### PR TITLE
issues#65  新增留言列表中留言數統計

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -9,7 +9,10 @@ class ArticleManager(models.Manager):
         return super().get_queryset().filter(deleted_at=None)
     
     def with_count(self):
-        return self.get_queryset().annotate(like_count=models.Count("like_article", distinct=True), comment_count=models.Count("comments", distinct=True))
+        return self.get_queryset().annotate(
+            like_count=models.Count('like_article', filter=models.Q(like_article__article__deleted_at__isnull=True), distinct=True),
+            comment_count=models.Count('comments', filter=models.Q(comments__deleted_at__isnull=True), distinct=True)
+        )
 
 
 class Article(models.Model):

--- a/articles/models.py
+++ b/articles/models.py
@@ -7,6 +7,9 @@ from boards.models import Category
 class ArticleManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().filter(deleted_at=None)
+    
+    def with_count(self):
+        return self.get_queryset().annotate(like_count=models.Count("like_article", distinct=True), comment_count=models.Count("comments", distinct=True))
 
 
 class Article(models.Model):

--- a/articles/views.py
+++ b/articles/views.py
@@ -9,7 +9,6 @@ from .forms import ArticleForm
 from comments.forms import CommentForm
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
-from django.db.models import Count
 from comments.models import LikeComment
 
 from .models import Category
@@ -20,19 +19,13 @@ class ArticleIndexView(ListView):
     template_name = "articles/index.html"
 
     def get_queryset(self):
-        category_id = self.kwargs.get("category_id")
-        return Article.objects.filter(category_id=category_id).annotate(like_count=Count("article"))
-    
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['category'] = get_object_or_404(Category, id=self.kwargs.get('category_id'))
-        return context
+        return Article.objects.with_count()
 
 @method_decorator(login_required, name="dispatch")
 class NewView(FormView):
     template_name = "articles/new.html"
     form_class = ArticleForm
-    success_url = reverse_lazy("artucles:index")
+    success_url = reverse_lazy("articles:index")
 
     def get_initial(self):
         initial = super().get_initial()

--- a/templates/articles/index.html
+++ b/templates/articles/index.html
@@ -45,9 +45,11 @@
           <a href="{% url 'articles:show' article.pk %}" class="block mt-4 text-blue-500 hover:underline">閱讀全文</a>
         </div>
       </div>
-      <div class="flex items-end">
-        <p>讚數統計: {{article.like_count}}</p>
-      </div>
+    </div>  
+    <div class="flex items-end">
+      <p class="mr-5">留言統計: {{article.comment_count}}</p>
+      <p>讚數統計: {{article.like_count}}</p>
+    </div>
     </div>
   </div>
   {% endfor %}

--- a/templates/articles/index.html
+++ b/templates/articles/index.html
@@ -46,11 +46,13 @@
         </div>
       </div>
     </div>  
-    <div class="flex items-end">
-      <p class="mr-5">留言統計: {{article.comment_count}}</p>
-      <p>讚數統計: {{article.like_count}}</p>
+    <div class="flex justify-end items-end">
+      <div class="mr-10 flex">
+        <p class="mr-5">留言統計: {{article.comment_count}}</p>
+        <p>讚數統計: {{article.like_count}}</p>
+      </div>
     </div>
-    </div>
+    
   </div>
   {% endfor %}
 </div>

--- a/templates/articles/new.html
+++ b/templates/articles/new.html
@@ -1,33 +1,21 @@
 {% extends "layouts/base.html" %}
 
 {% block content %}
-<div class="flex flex-col bg-slate-300 rounded-md p-6 max-w-xl mx-auto mt-[62px] relative" style="height: calc(100vh - 96.97px);">
-    <div class="flex flex-col w-24">
-        <h2 class="inline-block text-2xl pb-4 mb-4 border-b-2 border-black">新增文章</h2>
-        <button class="inline-flex items-center justify-center text-sm bg-gray-900 hover:bg-gray-700 text-white rounded-md py-2">
-            工作版
-        </button>
-    </div>
-    <div class="flex-1">
-        <form action="{% url 'articles:add' %}" method="POST">
-            {% csrf_token %}
-            <div class="my-4">
-                <label class="block text-xl text-black font-medium mb-1" for="id_title">{{ form.title.label }}</label>
-                {{ form.title }}
-            </div>
-            <div class="mb-4">
-                <label class="block text-xl text-black font-medium mb-1" for="id_author">{{ form.author.label }}</label>
-                {{ form.author }}
-            </div>
-            <div class="mb-4">
-                <label class="block text-xl text-black font-medium mb-1" for="id_content">{{ form.content.label }}</label>
-                {{ form.content }}
-            </div>
-            {{ form.category }}
 
-            <div class="flex justify-center gap-2">
-                <a class="inline-flex items-center justify-center text-sm hover:bg-slate-400 text-black rounded-md px-6 py-3" value="取消" href="{% url 'articles:index' category.id %}">取消</a>
-                <button class="inline-flex items-center justify-center text-sm bg-sky-500 hover:bg-sky-300 text-white rounded-md px-6 py-3" type="submit" value="新增">新增</button>
+<div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-gray-50 sm:px-6 lg:px-8">
+    <div class="w-full max-w-2xl p-8 space-y-8 border border-gray-200 rounded-lg">
+        <div>
+            <h2 class="mt-6 text-2xl font-bold tracking-tight text-center text-gray-800 sm:text-3xl">
+                新增文章
+            </h2>
+        </div>
+        <form class="space-y-6" action="{% url 'articles:add' %}" method="POST">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <div class="flex justify-center">
+                <button
+                    class="px-6 py-3 text-white bg-gray-300 rounded-lg hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-gray-800"
+                    type="submit" value="新增">新增</button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
[影片](https://youtu.be/oVUFipo99UU)
1. articles.view.py class ArticleIndexView(ListView)裡 def get_queryset(self): 回傳 Article.objects.with_count() 函數
2. articles.model.py 裡 class ArticleManager 定義一個 with_count(self) 函數
def with_count(self):
        return self.get_queryset().annotate(
            like_count=models.Count('like_article', filter=models.Q(li), distinct=True),
            comment_count=models.Count('comments', filter=models.Q(comments__deleted_at__isnull=True), distinct=True)
        )
self.get_query 使用 annotate 加入兩個屬性 like_count, comment_count , models.Count 是計算數量 filter=models.Q 用來過滤 like_article__article__deleted_at__isnull=True,會這樣寫主要從反向查尋的 like_article 是一個 join table ,這個 join table 裡面只有記載 文章跟使用者的 id 沒有 deleted_at 這個欄位，所以才會在 like_article 後再接 article__deleted_at 如果是 null 就是 True 這樣就能過滤軟刪除的留言數，