### PR TITLE
issues#80 按讚不換頁(留言) / 按讚總數同步更新

### DIFF
--- a/articles/views.py
+++ b/articles/views.py
@@ -118,7 +118,6 @@ class ArticleUpdateView(UpdateView):
     def get_success_url(self):
         return reverse_lazy("articles:show", kwargs={"pk": self.object.id})
 
-
 @login_required
 def edit(request, id):
     article = get_object_or_404(Article, pk=id)

--- a/comments/urls.py
+++ b/comments/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
-from . import views
-from .views import CommentListView, add_like, remove_like
+from .views import CommentListView, add_like, remove_like, CommentDeleteView
 
 app_name = "comments"
 
 urlpatterns = [
-    path("<pk>/delete/", views.delete, name="delete"),
+    path("<pk>/delete/", CommentDeleteView.as_view(), name="delete"),
     path("<pk>/add_like", add_like, name="add_like"),
     path("<pk>/remove_like", remove_like, name="remove_like"),
     path("<pk>/", CommentListView.as_view(), name="list"),

--- a/comments/views.py
+++ b/comments/views.py
@@ -1,14 +1,13 @@
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse_lazy, reverse
 from django.views.decorators.http import require_POST
 from django.views.generic import ListView, CreateView, DeleteView
-from django.contrib import messages
 from members.models import Member
 from .models import Comment, LikeComment
 from .forms import CommentForm
 from articles.models import Article
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
+from django.urls import reverse_lazy
 
 
 @method_decorator(login_required, name="dispatch")
@@ -57,14 +56,11 @@ class CommentCreateView(CreateView):
         context["article"] = article
         return context
 
-
-@require_POST
-def delete(request, pk):
-    comment = get_object_or_404(Comment, pk=pk)
-    article_id = comment.article_id
-    comment.delete()
-    return redirect("articles:show", pk=article_id)
-
+class CommentDeleteView(DeleteView):
+    model = Comment
+    template_name = "articles/article_detail.html"   
+    def get_success_url(self):
+        return reverse_lazy("articles:show", kwargs={"pk": self.object.article_id})
 
 @login_required
 @require_POST

--- a/comments/views.py
+++ b/comments/views.py
@@ -69,7 +69,7 @@ def add_like(req, pk):
     comment.like_comment.add(req.user)
     comment.save()
     comment.is_like = True
-    comment.like_count = LikeComment.objects.filter(like_by=req.user).count()
+    comment.like_count = LikeComment.objects.filter(like_comment=pk).count()
     return render(req, "shared/like_comment_btn.html", {"comment": comment})
 
 
@@ -79,5 +79,5 @@ def remove_like(req, pk):
     comment = get_object_or_404(Comment, id=pk)
     comment.like_comment.remove(req.user)
     comment.is_like = False
-    comment.like_count = LikeComment.objects.filter(like_by=req.user).count()
+    comment.like_count = LikeComment.objects.filter(like_comment=pk).count()
     return render(req, "shared/like_comment_btn.html", {"comment": comment})

--- a/templates/articles/article_detail.html
+++ b/templates/articles/article_detail.html
@@ -49,22 +49,7 @@
           </div>
           <div class="flex justify-end pb-2 pr-4">
 
-            <div class="flex items-center">
-              {% if comment.is_like %}
-              <form action="{% url 'comments:remove_like' comment.id %}" method="post">
-                {% csrf_token %}
-                <button
-                  class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear bg-red-400 rounded shadow active:bg-slate-700 text-slate-700 focus:outline-none focus:shadow-sky-800 ">取消讚</button>
-              </form>
-              {% else %}
-              <form action="{% url 'comments:add_like' comment.id %}" method="post">
-                {% csrf_token %}
-                <button
-                  class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear rounded shadow active:bg-slate-700 text-slate-700 bg-sky-400 focus:outline-none focus:shadow-sky-800 ">點讚</button>
-              </form>
-              {% endif %}
-              <p class="mr-10">讚: {{comment.like_count}}</p>
-            </div>
+            {% include 'shared/like_comment_btn.html' %}
 
             <form action="{% url 'comments:delete' pk=comment.id %}" method="post" class="inline">
               {% csrf_token %}

--- a/templates/articles/article_detail.html
+++ b/templates/articles/article_detail.html
@@ -49,7 +49,7 @@
           </div>
           <div class="flex justify-end pb-2 pr-4">
 
-            {% include 'shared/like_comment_btn.html' %}
+              {% include 'shared/like_comment_btn.html' %}
 
             <form action="{% url 'comments:delete' pk=comment.id %}" method="post" class="inline">
               {% csrf_token %}

--- a/templates/shared/like_comment_btn.html
+++ b/templates/shared/like_comment_btn.html
@@ -1,0 +1,16 @@
+<div id="like_comment_btn" class="flex items-center">
+  {% if comment.is_like %}
+  <form hx-post="{% url 'comments:remove_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn" hx-swap="outHTML" >
+    {% csrf_token %}
+    <button
+      class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear bg-red-400 rounded shadow active:bg-slate-700 focus:outline-none focus:shadow-sky-800 ">取消讚</button>
+  </form>
+  {% else %}
+  <form hx-post="{% url 'comments:add_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn" hx-swap="outHTML">
+    {% csrf_token %}
+    <button
+      class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear rounded shadow active:bg-slate-700 bg-sky-400 focus:outline-none focus:shadow-sky-800 ">點讚</button>
+  </form>
+  {% endif %}
+  <p  class="mr-10">讚: {{comment.like_count}}</p>
+</div>

--- a/templates/shared/like_comment_btn.html
+++ b/templates/shared/like_comment_btn.html
@@ -1,12 +1,12 @@
-<div id="like_comment_btn" class="flex items-center">
+<div id="like_comment_btn-{{comment.id}}" class="flex items-center">
   {% if comment.is_like %}
-  <form hx-post="{% url 'comments:remove_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn" hx-swap="outHTML" >
+  <form hx-post="{% url 'comments:remove_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn-{{comment.id}}" hx-swap="outHTML" >
     {% csrf_token %}
     <button
       class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear bg-red-400 rounded shadow active:bg-slate-700 focus:outline-none focus:shadow-sky-800 ">取消讚</button>
   </form>
   {% else %}
-  <form hx-post="{% url 'comments:add_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn" hx-swap="outHTML">
+  <form hx-post="{% url 'comments:add_like' comment.id %}" hx-throttle="500ms" hx-target="#like_comment_btn-{{comment.id}}" hx-swap="outHTML">
     {% csrf_token %}
     <button
       class="px-2 py-1 mx-2 mb-1 font-bold text-white uppercase duration-150 ease-linear rounded shadow active:bg-slate-700 bg-sky-400 focus:outline-none focus:shadow-sky-800 ">點讚</button>


### PR DESCRIPTION


https://github.com/astrocamp/16th-Diswork/assets/101399488/8b94a376-4eff-429a-a2dd-97d2923876a2

1. 新增 一個 like_comment_btn 頁面把 留言按紐跟留言總數拉出成獨立一個頁面
2. 修改 articles/article_detail.html 引入 like_comment_btn 頁面
3. 修改 comments/views.py 按讚/取點讚 按紐 邏輯
4. 修改 articles/views.py  程式碼 進入編輯文章頁/編輯文章送出表單程式碼隔開
5. 修改 comments/views.py 刪除留言邏輯改為 CBV 編寫
6. 修改 comments/urls.py 刪除留言路由變更
7. 修改 comments/views.py  按讚總數邏輯
8.  like_comment_btn 頁面每個點讚/取消讚按紐正常