### PR TITLE
issues#83 登入前後顯示按鈕切換

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -2,17 +2,23 @@
 {% load static %}
 {% block content %}
 <div class="slick-carousel sticky top-[68px] flex gap-2 overflow-hidden">
-    {% for item in news_items%}
-    <div class="bg-blue-500">
-        <a class="block w-screen p-2 text-center text-white" href="{{ item.url }}">{{ item.title }}</a>
-    </div>
-    {% endfor %}
+  {% for item in news_items%}
+  <div class="bg-blue-500">
+    <a class="block w-screen p-2 text-center text-white" href="{{ item.url }}">{{ item.title }}</a>
+  </div>
+  {% endfor %}
 </div>
 
 <main style="min-height: calc(100vh - 107.97px);">
   <section class="flex flex-col-reverse items-center justify-between px-6 py-20 text-white bg-gray-900 md:px-12">
     <div class="flex w-full max-w-xl mt-10 text-center">
       {% if user.is_authenticated %}
+      <div class="w-1/2 mr-2 bg-gray-300 hover:bg-amber-500 rounded-3xl">
+        <a href="{% url 'boards:list' %}" class="block w-full py-3 text-black hover:text-white">進入討論版</a>
+      </div>
+      <div class="w-1/2 ml-2 bg-gray-300 hover:bg-amber-500 rounded-3xl ">
+        <a href="#" class="block w-full py-3 text-black hover:text-white">訂閱我們</a>
+      </div>
       {% else %}
       <div class="w-1/2 mr-2 bg-gray-300 hover:bg-amber-500 rounded-3xl">
         <a href="{% url 'members:register' %}" class="block w-full py-3 text-black hover:text-white">註冊加入DISWORK</a>
@@ -76,17 +82,19 @@
             <p class="mt-4 text-xl text-white">🐱 管理板中發文及留言</p>
           </div>
           <div class="flex-grow"></div>
+          {% if user.is_authenticated %}
           {% if member_status %}
           <a class="inline-block w-full h-12 px-4 mt-6 text-2xl font-bold leading-loose text-center text-white bg-orange-400 rounded-lg hover:bg-orange-500"
             disabled>已訂閱</a>
           {% else %}
-          <form action="{% url 'members:subscribe' %}" method="POST">
+          <form action="{% url 'members:subscribe' %}" method="POST" class="w-full">
             {% csrf_token %}
             <button type="submit"
               class="inline-block w-full h-12 px-4 mt-6 text-2xl font-bold leading-loose text-center text-white bg-orange-400 rounded-lg hover:bg-orange-500">
               訂閱
             </button>
           </form>
+          {% endif %}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
1.登入前後按鈕從 註冊加入/登入使用 --> 進入討論版/訂閱
2.進入討論版正常，訂閱需要加入跳轉頁面
3.調整需登入才能看見訂閱or已訂閱按鈕，不然在未註冊登入前看到訂閱按鈕似乎不太對，加上如果沒有註冊登入直接按下訂閱按鈕可能會發生其他錯誤

https://github.com/astrocamp/16th-Diswork/assets/99263019/e588edda-5181-434a-a344-744b36c98bcf

